### PR TITLE
Declare `#include <cstddef>` in romaji_weight.hpp

### DIFF
--- a/src/measure/romaji_weight.hpp
+++ b/src/measure/romaji_weight.hpp
@@ -20,6 +20,7 @@ limitations under the License.
 #ifndef RESEMBLA_ROMAJI_WEIGHT_HPP
 #define RESEMBLA_ROMAJI_WEIGHT_HPP
 
+#include <cstddef>
 #include <unordered_set>
 
 namespace resembla {


### PR DESCRIPTION
To fix the compilation error by g++ 12.2.0+, like the following:

```
10.74 In file included from romaji_weight.cpp:20:
10.74 romaji_weight.hpp:35:69: error: ‘size_t’ has not been declared
10.74    35 |     double operator()(const value_type c, bool is_original = false, size_t total = -1, size_t position = -1) const;
10.74       |                                                                     ^~~~~~
```