### PR TITLE
Add missing namespace names (icu::)

### DIFF
--- a/src/string_normalizer.cpp
+++ b/src/string_normalizer.cpp
@@ -46,8 +46,8 @@ StringNormalizer::StringNormalizer(const std::string& nrm_dir, const std::string
 
         UParseError parse_error;
         UErrorCode error_code = U_ZERO_ERROR;
-        transliterator.reset(Transliterator::createFromRules("resembla_transliteration",
-                UnicodeString(rules.c_str()), UTRANS_FORWARD, parse_error, error_code));
+        transliterator.reset(icu::Transliterator::createFromRules("resembla_transliteration",
+                icu::UnicodeString(rules.c_str()), UTRANS_FORWARD, parse_error, error_code));
         if(U_FAILURE(error_code)){
             throw std::runtime_error("failed to normalize input");
         }

--- a/src/string_normalizer.hpp
+++ b/src/string_normalizer.hpp
@@ -45,7 +45,7 @@ public:
         }
 
         UErrorCode error_code = U_ZERO_ERROR;
-        auto work = cast_string<UnicodeString>(input);
+        auto work = cast_string<icu::UnicodeString>(input);
         if(normalizer_resembla != nullptr){
             work = normalizer_resembla->normalize(work, error_code);
             if(U_FAILURE(error_code)){

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -61,25 +61,25 @@ void cast_string(const std::wstring& src, std::string& dest)
 }
 
 template<>
-void cast_string(const std::string& src, UnicodeString& dest)
+void cast_string(const std::string& src, icu::UnicodeString& dest)
 {
-    dest = UnicodeString::fromUTF8(src);
+    dest = icu::UnicodeString::fromUTF8(src);
 }
 
 template<>
-void cast_string(const UnicodeString& src, std::string& dest)
+void cast_string(const icu::UnicodeString& src, std::string& dest)
 {
     src.toUTF8String(dest);
 }
 
 template<>
-void cast_string(const std::wstring& src, UnicodeString& dest)
+void cast_string(const std::wstring& src, icu::UnicodeString& dest)
 {
-    dest = UnicodeString::fromUTF8(cast_string<std::string>(src));
+    dest = icu::UnicodeString::fromUTF8(cast_string<std::string>(src));
 }
 
 template<>
-void cast_string(const UnicodeString& src, std::wstring& dest)
+void cast_string(const icu::UnicodeString& src, std::wstring& dest)
 {
     std::string tmp;
     src.toUTF8String(tmp);

--- a/src/symbol_normalizer.cpp
+++ b/src/symbol_normalizer.cpp
@@ -30,12 +30,12 @@ SymbolNormalizer::SymbolNormalizer(const std::string& nrm_dir, const std::string
 {
     UErrorCode error_code = U_ZERO_ERROR;
     normalizer_resembla = !nrm_dir.empty() ?
-        Normalizer2::getInstance(nrm_dir.c_str(), nrm_name.c_str(), UNORM2_COMPOSE, error_code) : nullptr;
+        icu::Normalizer2::getInstance(nrm_dir.c_str(), nrm_name.c_str(), UNORM2_COMPOSE, error_code) : nullptr;
     if(normalizer_resembla != nullptr && U_FAILURE(error_code)) {
         throw std::runtime_error("failed to initialize normalizer");
     }
     normalizer_nfkc = !predefined_nrm_name.empty() ?
-        Normalizer2::getInstance(NULL, predefined_nrm_name.c_str(), UNORM2_COMPOSE, error_code) : nullptr;
+        icu::Normalizer2::getInstance(NULL, predefined_nrm_name.c_str(), UNORM2_COMPOSE, error_code) : nullptr;
     if(normalizer_nfkc != nullptr && U_FAILURE(error_code)) {
         throw std::runtime_error("failed to initialize normalizer");
     }

--- a/src/symbol_normalizer.hpp
+++ b/src/symbol_normalizer.hpp
@@ -45,7 +45,7 @@ public:
         }
 
         UErrorCode error_code = U_ZERO_ERROR;
-        auto work = cast_string<UnicodeString>(input);
+        auto work = cast_string<icu::UnicodeString>(input);
         if(normalizer_resembla != nullptr){
             work = normalizer_resembla->normalize(work, error_code);
             if(U_FAILURE(error_code)) {
@@ -63,8 +63,8 @@ public:
     }
 
 protected:
-    const Normalizer2* normalizer_resembla;
-    const Normalizer2* normalizer_nfkc;
+    const icu::Normalizer2* normalizer_resembla;
+    const icu::Normalizer2* normalizer_nfkc;
     bool to_lower;
 };
 


### PR DESCRIPTION
This fixes errors when Resembla is used with a later version of ICU.

---

On Ubuntu 24.04 with ICU 74.2, I saw compilation errors as follows:

```
symbol_normalizer.hpp:66:11: error: ‘Normalizer2’ does not name a type; did you mean ‘UNormalizer2’?
   66 |     const Normalizer2* normalizer_resembla;
      |           ^~~~~~~~~~~
      |           UNormalizer2

string_normalizer.hpp:48:33: error: ‘UnicodeString’ was not declared in this scope; did you mean ‘icu_74::UnicodeString’?
   48 |         auto work = cast_string<UnicodeString>(input);
      |                                 ^~~~~~~~~~~~~
      |                                 icu_74::UnicodeString

string_normalizer.cpp:49:30: error: ‘Transliterator’ has not been declared
   49 |         transliterator.reset(Transliterator::createFromRules("resembla_transliteration",
      |                              ^~~~~~~~~~~~~~
```

These errors are caused by missing namespace names (`icu::`).
